### PR TITLE
Fix issue where screenshare is not shown if you join after the screenshare started

### DIFF
--- a/src/services/Janusservice.js
+++ b/src/services/Janusservice.js
@@ -114,7 +114,7 @@ export const janusHelpers = {
           }
           switch (event) {
             case "joined":
-                console.log(`joined`)
+              console.log(`joined`);
               store.commit("setMyPrivateId", msg["private_id"]);
               janusHelpers.publishOwnFeed();
 
@@ -399,16 +399,13 @@ export const janusHelpers = {
     joinScreen(id) {
       store.commit("setScreenShareRoom", parseInt(id));
       store.commit("setScreenShareRole", "listener");
-
       let me = JSON.parse(window.localStorage.getItem("account"));
-
       const register = {
         request: "join",
         room: store.getters.screenShareRoom,
         ptype: "publisher",
         display: me.name,
       };
-
       console.log(
         "Screen share joined: ",
         store.getters.users[0].screenSharePluginHandle,

--- a/src/stores/JanusStore.js
+++ b/src/stores/JanusStore.js
@@ -79,7 +79,9 @@ export default {
         console.log("I am a publisher, cant join again ...")
         return;
       }
-      janusHelpers.screenShare.onJanusCreateSuccess(() => janusHelpers.screenShare.joinScreen(id));
+      setTimeout(() => {
+        janusHelpers.screenShare.onJanusCreateSuccess(() => janusHelpers.screenShare.joinScreen(id));
+      }, 200);
     },
     stopScreenShare(state) {
       state.screenShareRole = null;


### PR DESCRIPTION
This is not the best fix in the world, it's just a tribute